### PR TITLE
feat: Melhorar pipeline CI para rodar testes automáticos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,13 @@ jobs:
               run: docker build -t monitoring-system .
 
             - name: Rodar Container
-              run: docker run -d -p 8000:8000 monitoring-system
+              run: docker run -d -p 8000:8000 --name monitoring-system monitoring-system
 
             - name: Esperar serviço iniciar
               run: sleep 5
 
             - name: Testar healthcheck
               run: curl --fail http://localhost:8000/healthcheck
+
+            - name: Realizar testes com pytest dentro do container
+              run: docker exec monitoring-system pytest /tests/test_healthcheck.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn
 python-dotenv
+pytest
+httpx

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,15 @@
+import sys
+import os
+from fastapi.testclient import TestClient
+from app.main import app
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
+
+client = TestClient(app)
+
+def test_healthcheck():
+    response = client.get("/healthcheck")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert "env" in data


### PR DESCRIPTION
- Antes de dar o build da imagem, adicione no pipeline:
  - Uma etapa Testar API.
  - Criar um arquivo test_healthcheck.py com um simples teste de GET /healthcheck.
- Se o teste falhar, o pipeline deve parar.

**Dicas:**
- Crie uma pasta tests/ com o arquivo test_healthcheck.py.
- Use pytest ou requests puro para fazer a chamada no teste.