### PR TITLE
feat: Criar novo endpoint /metrics no FastAPI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import os
+import random
 from fastapi import FastAPI
 from dotenv import load_dotenv
 
@@ -12,3 +13,7 @@ app = FastAPI()
 @app.get("/healthcheck")
 def healthcheck():
     return { "status": "ok", "env": ENV }
+
+@app.get("/metrics")
+def metricks():
+    return { "cpu_usage": f"{random.randint(10,90)}%", "memory_usage": f"{random.randint(100,800)}MB" }


### PR DESCRIPTION
- Criar um endpoint /metrics que simula uma métrica do sistema.
- Retornar um JSON com:
  - cpu_usage: número aleatório de 10% a 90%.
  - memory_usage: número aleatório de 100MB a 800MB.