### PR TITLE
feat: Criar endpoint /uptime-rank

### DIFF
--- a/app/routers/monitoring.py
+++ b/app/routers/monitoring.py
@@ -2,7 +2,7 @@ import os
 import random
 from fastapi import APIRouter
 from dotenv import load_dotenv
-from app.schemas.monitoring import StatusSummary, SystemStatus
+from app.schemas.monitoring import StatusSummary, Uptimes
 
 if os.getenv("ENV") is None:
     load_dotenv()
@@ -45,3 +45,8 @@ async def status_summary(status: StatusSummary):
         "fail": fail_count,
         "percent_ok": percent_ok
     }
+
+@router.post("/uptime-rank")
+async def uptime_rank(uptime: Uptimes):
+    classificacao = sorted(uptime.uptimes, key=lambda system: system.uptime, reverse=True)    
+    return classificacao

--- a/app/schemas/monitoring.py
+++ b/app/schemas/monitoring.py
@@ -7,3 +7,10 @@ class SystemStatus(BaseModel):
 
 class StatusSummary(BaseModel):
     systems: List[SystemStatus]
+
+class SystemsUptimes(BaseModel):
+    name: str
+    uptime: int
+
+class Uptimes(BaseModel):
+    uptimes: List[SystemsUptimes]

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -46,3 +46,19 @@ def test_status_summary():
     assert data["ok"] == 2
     assert data["fail"] == 1
     assert data["percent_ok"] == 66.7
+
+def test_uptime_rank():
+    payload = {
+        "uptimes": [
+            {"name": "serviceA", "uptime": 231},
+            {"name": "serviceB", "uptime": 482},
+            {"name": "serviceC", "uptime": 123}
+        ]
+    }
+    response = client.post("/api/uptime-rank", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["uptime"] == 482 and data[0]["name"] == "serviceB"
+    assert data[1]["uptime"] == 231 and data[1]["name"] == "serviceA"
+    assert data[2]["uptime"] == 123 and data[2]["name"] == "serviceC"
+


### PR DESCRIPTION
Objetivo: Receber uma lista de sistemas com seus tempos de atividade e retornar ordenado do maior para o menor.
Input (JSON):
{
  "uptimes": [
    {"name": "serviceA", "uptime": 231},
    {"name": "serviceB", "uptime": 482},
    {"name": "serviceC", "uptime": 123}
  ]
}
Output:
[
  {"name": "serviceB", "uptime": 482},
  {"name": "serviceA", "uptime": 231},
  {"name": "serviceC", "uptime": 123}
]