### PR TITLE
feat: Criar endpoint /alert-count

### DIFF
--- a/app/routers/monitoring.py
+++ b/app/routers/monitoring.py
@@ -2,7 +2,7 @@ import os
 import random
 from fastapi import APIRouter
 from dotenv import load_dotenv
-from app.schemas.monitoring import StatusSummary, Uptimes
+from app.schemas.monitoring import StatusSummary, Uptimes, Alerts
 
 if os.getenv("ENV") is None:
     load_dotenv()
@@ -50,3 +50,13 @@ async def status_summary(status: StatusSummary):
 async def uptime_rank(uptime: Uptimes):
     classificacao = sorted(uptime.uptimes, key=lambda system: system.uptime, reverse=True)    
     return classificacao
+
+@router.post("/alert-count")
+async def alert_count(alert: Alerts):
+    alert_counts = {}
+    for alert in alert.alerts:
+        if alert not in alert_counts:
+            alert_counts[alert] = 0
+        alert_counts[alert] += 1
+    
+    return alert_counts

--- a/app/schemas/monitoring.py
+++ b/app/schemas/monitoring.py
@@ -14,3 +14,6 @@ class SystemsUptimes(BaseModel):
 
 class Uptimes(BaseModel):
     uptimes: List[SystemsUptimes]
+
+class Alerts(BaseModel):
+    alerts: List[str]

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -62,3 +62,13 @@ def test_uptime_rank():
     assert data[1]["uptime"] == 231 and data[1]["name"] == "serviceA"
     assert data[2]["uptime"] == 123 and data[2]["name"] == "serviceC"
 
+def test_alert_count():
+    payload = {
+        "alerts": ["disk", "cpu", "disk", "memory", "cpu", "cpu"]
+    }
+    response = client.post("/api/alert-count", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["disk"] == 2
+    assert data["cpu"] == 3
+    assert data["memory"] == 1


### PR DESCRIPTION
Objetivo: Contar o número de alertas por tipo.
Input (JSON):
{
  "alerts": ["disk", "cpu", "disk", "memory", "cpu", "cpu"]
}
Output:
{
  "disk": 2,
  "cpu": 3,
  "memory": 1
}